### PR TITLE
fix: check file content when testFormat is empty

### DIFF
--- a/src/plugins/imageformats/apng/apngimageplugin.cpp
+++ b/src/plugins/imageformats/apng/apngimageplugin.cpp
@@ -8,13 +8,20 @@ ApngImagePlugin::ApngImagePlugin(QObject *parent) :
 
 QImageIOPlugin::Capabilities ApngImagePlugin::capabilities(QIODevice *device, const QByteArray &format) const
 {
-	if (format == "apng") {
-		if(device && device->bytesAvailable() >= 8)
-			return ApngReader::checkPngSig(device) ? CanRead : static_cast<Capability>(0);
-		else
-			return CanRead;
-	} else
+	// when format is apng, return CanRead directly.
+	if (format == "apng")
+		return CanRead;
+	if (!format.isEmpty())
 		return static_cast<Capability>(0);
+	if (!device->isOpen())
+		return static_cast<Capability>(0);
+
+	// formats can be empty, thus we need to detect the content inside device.
+	if (device->isReadable() && device->bytesAvailable() >= 8) {
+		return ApngReader::checkPngSig(device) ? CanRead : static_cast<Capability>(0);
+	}
+
+	return static_cast<Capability>(0);
 }
 
 QImageIOHandler *ApngImagePlugin::create(QIODevice *device, const QByteArray &format) const


### PR DESCRIPTION
> QImageIOPlugin::Capabilities QImageIOPlugin::capabilities(QIODevice *device, const QByteArray &format) const:
> 
> ... If device is 0, it should simply report whether the format can be read or written. Otherwise, it should attempt to determine whether the given format (or any format supported by the plugin if format is empty)
>  [Qt 5 Documentation](https://doc.qt.io/qt-5/qimageioplugin.html#capabilities)

According to the documentation, `format` could be empty. In this case, we will need to check the content of the device to determine the actual capability.

It will happen if we use `QImageReader::setDecideFormatFromContent(true)`. Then the extension of the file will be ignored and the `format` argument will be an empty `QByteArray`.

> ``` c++
> if (ignoresFormatAndExtension)
>     testFormat = QByteArray();
> ```
> [qtbase qimagereader.cpp](https://github.com/qt/qtbase/blob/63ffae3fa3a2627401878e7b948cb730118dc226/src/gui/image/qimagereader.cpp#L231-L232)

This patch aligned the way to do the check to Qt. See [the jpeg imageformat plugin source code from qtbase](https://code.woboq.org/qt5/qtbase/src/plugins/imageformats/jpeg/main.cpp.html#49). This means we could just return `CanRead` directly if `format` is `"apng"`, and will also check the content if `format` is empty and `device` is readable.

Tested under Windows with MSYS2/MinGW64 and Qt 5.15.2 from MSYS2 repo. Let me know if you need any additional info.

Thanks!
