### PR TITLE
fix: return proper image size for QImageIOHandler::Size

### DIFF
--- a/src/plugins/imageformats/apng/apngreader.cpp
+++ b/src/plugins/imageformats/apng/apngreader.cpp
@@ -137,11 +137,16 @@ void ApngReader::info_fn(png_structp png_ptr, png_infop info_ptr)
 	(void)png_set_interlace_handling(png_ptr);
 	png_read_update_info(png_ptr, info_ptr);
 
+	quint32 width = png_get_image_width(png_ptr, info_ptr);
+	quint32 height = png_get_image_height(png_ptr, info_ptr);
+	reader->_imageSize.setWidth(width);
+	reader->_imageSize.setHeight(height);
+
 	//init read frame struct
 	frame.x = 0;
 	frame.y = 0;
-	frame.width = png_get_image_width(png_ptr, info_ptr);
-	frame.height = png_get_image_height(png_ptr, info_ptr);
+	frame.width = width;
+	frame.height = height;
 	frame.channels = png_get_channels(png_ptr, info_ptr);
 	frame.delay_num = 0;
 	frame.delay_den = 10;


### PR DESCRIPTION
`_imageSize` seems declared but unused/not initialized, cause `size()` won't return a proper size.

Also seen in #11 :

> In addition, QImageReader::size only gives a correct value a period of time after the QMovie begins playing.