### PR TITLE
fix: show format as PNG if it's not an APNG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ Thumbs.db
 
 # qpm
 vendor
+
+# Visual Studio Code settings
+.vscode/
+
+# Generic build folder
+build/

--- a/src/plugins/imageformats/apng/apngimagehandler.cpp
+++ b/src/plugins/imageformats/apng/apngimagehandler.cpp
@@ -17,7 +17,7 @@ bool ApngImageHandler::canRead() const
 {
 	auto valid = _reader->init(device());
 	if(valid)
-		setFormat("apng");
+		setFormat(_reader->isAnimated() ? "apng" : "png");
 	return valid && _index < _reader->frames();
 }
 

--- a/src/plugins/imageformats/apng/apngimagehandler_p.h
+++ b/src/plugins/imageformats/apng/apngimagehandler_p.h
@@ -15,7 +15,7 @@ public:
 	~ApngImageHandler() override;
 
 	// QImageIOHandler interface
-	QByteArray name() const;
+	QByteArray name() const override;
 	bool canRead() const final;
 	bool read(QImage *image) final;
 	QVariant option(ImageOption option) const final;


### PR DESCRIPTION
In the current implementation, if we use `QImageReader::setDecideFormatFromContent(true)`, regular PNG files will also be handled by this plugin, and in this case, this plugin will always return "apng" as its format whether it's a regular PNG file or an APNG file. This patch is intended to fix this issue.

Another way to fix this is not handling regular PNG files at all, since I'm not familiar with APNG file structure, I choose the simplest way for now. Feel free to close this PR if you think this is not the right way to resolve this issue.

p.s. I got a question I'd like to ask. When manually renaming a valid `xxx.apng` file to `xxx.png`, this plugin will no longer recognize if it's an animated PNG or not even if we did `QImageReader::setDecideFormatFromContent(true)`, not sure why. Should I open a separate issue for this? Thanks.